### PR TITLE
Depend on cl-bodge/appkit instead of bodge-appkit

### DIFF
--- a/hello-bodge-physics.asd
+++ b/hello-bodge-physics.asd
@@ -4,7 +4,7 @@
   :author "Pavel Korolev"
   :license "MIT"
   :mailto "dev@borodust.org"
-  :depends-on (cl-bodge/physics cl-bodge/physics/3d cl-bodge/physics/2d bodge-appkit)
+  :depends-on (cl-bodge/physics cl-bodge/physics/3d cl-bodge/physics/2d cl-bodge/appkit)
   :pathname "src"
   :serial t)
 


### PR DESCRIPTION
After bodge-appkit has been deprecated, this project should depend on cl-bodge/appkit